### PR TITLE
Add light mode theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="default-dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -87,6 +87,9 @@
             <div class="header-actions">
                 <button class="header-btn" id="export-prompts-btn" title="Export Prompts">
                     <i class="fas fa-file-export"></i>
+                </button>
+                <button class="header-btn" id="theme-toggle-btn" title="Toggle Theme">
+                    <i class="fas fa-sun"></i>
                 </button>
                 <button class="header-btn" id="settings-btn" title="Settings">
                     <i class="fas fa-cog"></i>

--- a/script.js
+++ b/script.js
@@ -31,16 +31,17 @@ class PromptForgeApp {
         };
 
         // Initialize DOM elements
-        this.dom = {
-            promptsGrid: document.getElementById('prompts-grid'),
-            searchInput: document.getElementById('search-input'),
-            newPromptBtn: document.getElementById('new-prompt-btn'),
-            filterTags: document.querySelectorAll('.filter-tag'),
-            sortSelect: document.getElementById('sort-select'),
-            exportBtn: document.getElementById('export-prompts-btn'),
-            newEditModal: document.getElementById('new-edit-prompt-modal'),
-            newEditModalTitle: document.getElementById('new-edit-modal-title'),
-            promptForm: document.getElementById('prompt-form'),
+            this.dom = {
+                promptsGrid: document.getElementById('prompts-grid'),
+                searchInput: document.getElementById('search-input'),
+                newPromptBtn: document.getElementById('new-prompt-btn'),
+                filterTags: document.querySelectorAll('.filter-tag'),
+                sortSelect: document.getElementById('sort-select'),
+                exportBtn: document.getElementById('export-prompts-btn'),
+                themeToggleBtn: document.getElementById('theme-toggle-btn'),
+                newEditModal: document.getElementById('new-edit-prompt-modal'),
+                newEditModalTitle: document.getElementById('new-edit-modal-title'),
+                promptForm: document.getElementById('prompt-form'),
             promptTitleInput: document.getElementById('prompt-title'),
             promptContentInput: document.getElementById('prompt-content'),
             promptTagsInput: document.getElementById('prompt-tags'),
@@ -63,6 +64,7 @@ class PromptForgeApp {
 
     init() {
         this.loadPrompts();
+        this.applyTheme();
         this.bindEvents();
         this.renderPrompts();
         this.setupInstallPrompt();
@@ -122,6 +124,36 @@ class PromptForgeApp {
                 this.installPromptShown = true;
                 installModal.remove();
             });
+        }
+    }
+
+    applyTheme() {
+        const savedTheme = localStorage.getItem('theme') || 'default-dark';
+        document.documentElement.setAttribute('data-theme', savedTheme);
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+            meta.setAttribute('content', savedTheme === 'default-light' ? '#ffffff' : '#000000');
+        }
+        if (this.dom.themeToggleBtn) {
+            this.dom.themeToggleBtn.innerHTML = savedTheme === 'default-dark'
+                ? '<i class="fas fa-sun"></i>'
+                : '<i class="fas fa-moon"></i>';
+        }
+    }
+
+    toggleTheme() {
+        const currentTheme = document.documentElement.getAttribute('data-theme') || 'default-dark';
+        const newTheme = currentTheme === 'default-dark' ? 'default-light' : 'default-dark';
+        document.documentElement.setAttribute('data-theme', newTheme);
+        localStorage.setItem('theme', newTheme);
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+            meta.setAttribute('content', newTheme === 'default-light' ? '#ffffff' : '#000000');
+        }
+        if (this.dom.themeToggleBtn) {
+            this.dom.themeToggleBtn.innerHTML = newTheme === 'default-dark'
+                ? '<i class="fas fa-sun"></i>'
+                : '<i class="fas fa-moon"></i>';
         }
     }
 
@@ -203,6 +235,7 @@ class PromptForgeApp {
         });
         this.dom.sortSelect.addEventListener('change', () => this.handleFilterAndSort());
         this.dom.exportBtn.addEventListener('click', () => this.exportPrompts());
+        this.dom.themeToggleBtn.addEventListener('click', () => this.toggleTheme());
         this.dom.promptForm.addEventListener('submit', (e) => {
             e.preventDefault();
             this.savePromptFromForm();

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 /* AMOLED Dark Theme Variables */
-:root {
+[data-theme="default-dark"] {
     --bg-primary: #000000;
     --bg-secondary: #0a0a0a;
     --bg-tertiary: #111111;
@@ -23,6 +23,33 @@
     --info: #00aaff;
     --gradient-primary: linear-gradient(135deg, #000000 0%, #1a1a1a 100%);
     --gradient-card: linear-gradient(135deg, #111111 0%, #1a1a1a 100%);
+}
+
+/* Default Light Theme Variables */
+[data-theme="default-light"] {
+    --bg-primary: #ffffff;
+    --bg-secondary: #f5f5f5;
+    --bg-tertiary: #e0e0e0;
+    --bg-card: #f5f5f5;
+    --bg-hover: #d0d0d0;
+    --bg-active: #c0c0c0;
+    --text-primary: #000000;
+    --text-secondary: #333333;
+    --text-muted: #666666;
+    --text-accent: #111111;
+    --accent-primary: #000000;
+    --accent-secondary: #1a1a1a;
+    --border: #cccccc;
+    --border-light: #d0d0d0;
+    --shadow: rgba(0, 0, 0, 0.05);
+    --shadow-medium: rgba(0, 0, 0, 0.1);
+    --shadow-heavy: rgba(0, 0, 0, 0.15);
+    --success: #008000;
+    --warning: #cc9900;
+    --danger: #cc0000;
+    --info: #006666;
+    --gradient-primary: linear-gradient(135deg, #ffffff 0%, #f5f5f5 100%);
+    --gradient-card: linear-gradient(135deg, #e0e0e0 0%, #f5f5f5 100%);
 }
 
 /* Reset & Base */


### PR DESCRIPTION
## Summary
- add light and dark theme variable sets and toggleable data-theme support
- insert theme toggle button in header and wire up JS to persist user preference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af16dc7548832abce9289a911c82d3