### PR TITLE
Add basic in-app chat interface for prompt testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,9 @@
                 <button class="header-btn" id="export-prompts-btn" title="Export Prompts">
                     <i class="fas fa-file-export"></i>
                 </button>
+                <button class="header-btn" id="chat-btn" title="Test Chat">
+                    <i class="fas fa-comments"></i>
+                </button>
                 <button class="header-btn" id="theme-toggle-btn" title="Toggle Theme">
                     <i class="fas fa-sun"></i>
                 </button>
@@ -136,6 +139,24 @@
                         <button type="submit" id="save-ai-settings" class="action-btn primary">Save Settings</button>
                     </div>
                 </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Chat Test Modal -->
+    <div id="chat-modal" class="modal">
+        <div class="modal-overlay"></div>
+        <div class="modal-content chat-modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">Test Chat</h2>
+                <button class="close-modal"><i class="fas fa-times"></i></button>
+            </div>
+            <div class="modal-body">
+                <div id="chat-messages" class="chat-messages"></div>
+                <div class="chat-input-container">
+                    <input type="text" id="chat-input" placeholder="Type a message...">
+                    <button id="chat-send-btn" class="action-btn primary">Send</button>
+                </div>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -30,6 +30,8 @@ class PromptForgeApp {
                               'PROMPT TO IMPROVE:'
         };
 
+        this.chatHistory = [];
+
         // Initialize DOM elements
             this.dom = {
                 promptsGrid: document.getElementById('prompts-grid'),
@@ -40,6 +42,7 @@ class PromptForgeApp {
                 importBtn: document.getElementById('import-prompts-btn'),
                 importInput: document.getElementById('import-prompts-input'),
                 exportBtn: document.getElementById('export-prompts-btn'),
+                chatBtn: document.getElementById('chat-btn'),
                 themeToggleBtn: document.getElementById('theme-toggle-btn'),
                 newEditModal: document.getElementById('new-edit-prompt-modal'),
                 newEditModalTitle: document.getElementById('new-edit-modal-title'),
@@ -58,7 +61,11 @@ class PromptForgeApp {
             detailDeleteBtn: document.getElementById('modal-delete-prompt-btn'),
             emptyState: document.getElementById('empty-state'),
             notificationContainer: document.getElementById('notification-container'),
-            closeModalBtns: document.querySelectorAll('.close-modal')
+            closeModalBtns: document.querySelectorAll('.close-modal'),
+            chatModal: document.getElementById('chat-modal'),
+            chatMessages: document.getElementById('chat-messages'),
+            chatInput: document.getElementById('chat-input'),
+            chatSendBtn: document.getElementById('chat-send-btn')
         };
         
         this.init();
@@ -239,6 +246,9 @@ class PromptForgeApp {
         this.dom.importBtn.addEventListener('click', () => this.dom.importInput.click());
         this.dom.importInput.addEventListener('change', (e) => this.importPrompts(e));
         this.dom.exportBtn.addEventListener('click', () => this.exportPrompts());
+        if (this.dom.chatBtn) {
+            this.dom.chatBtn.addEventListener('click', () => this.showChatModal());
+        }
         this.dom.themeToggleBtn.addEventListener('click', () => this.toggleTheme());
         this.dom.promptForm.addEventListener('submit', (e) => {
             e.preventDefault();
@@ -257,6 +267,18 @@ class PromptForgeApp {
         this.dom.closeModalBtns.forEach(btn => {
             btn.addEventListener('click', (e) => this.closeModal(e.target.closest('.modal')));
         });
+
+        if (this.dom.chatSendBtn) {
+            this.dom.chatSendBtn.addEventListener('click', () => this.sendChatMessage());
+        }
+        if (this.dom.chatInput) {
+            this.dom.chatInput.addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    this.sendChatMessage();
+                }
+            });
+        }
 
         // Initialize AI Settings elements
         this.dom.aiSettingsModal = document.getElementById('ai-settings-modal');
@@ -735,6 +757,65 @@ class PromptForgeApp {
         } finally {
             this.dom.enhancePromptBtn.disabled = false;
             this.dom.enhancePromptBtn.innerHTML = '<i class="fas fa-magic"></i> Enhance with AI';
+        }
+    }
+
+    showChatModal() {
+        if (this.dom.chatModal) {
+            this.dom.chatModal.classList.add('active');
+            this.dom.chatInput?.focus();
+        }
+    }
+
+    appendChatMessage(sender, text) {
+        if (!this.dom.chatMessages) return;
+        const div = document.createElement('div');
+        div.className = `chat-message ${sender}`;
+        div.textContent = text;
+        this.dom.chatMessages.appendChild(div);
+        this.dom.chatMessages.scrollTop = this.dom.chatMessages.scrollHeight;
+    }
+
+    async sendChatMessage() {
+        if (!this.dom.chatInput) return;
+        const message = this.dom.chatInput.value.trim();
+        if (!message) return;
+
+        if (!this.aiSettings.apiKey || !this.aiSettings.model) {
+            this.showNotification('Please configure AI settings first', 'error');
+            this.showAiSettingsModal();
+            return;
+        }
+
+        this.appendChatMessage('user', message);
+        this.dom.chatInput.value = '';
+        this.chatHistory.push({ role: 'user', content: message });
+
+        if (this.dom.chatSendBtn) this.dom.chatSendBtn.disabled = true;
+
+        try {
+            const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${this.aiSettings.apiKey}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    model: this.aiSettings.model,
+                    messages: [{ role: 'system', content: 'You are a helpful assistant.' }, ...this.chatHistory]
+                })
+            });
+
+            if (!response.ok) throw new Error('API request failed');
+
+            const result = await response.json();
+            const reply = result.choices[0]?.message?.content?.trim() || 'No response';
+            this.appendChatMessage('bot', reply);
+            this.chatHistory.push({ role: 'assistant', content: reply });
+        } catch (error) {
+            this.appendChatMessage('bot', `Error: ${error.message}`);
+        } finally {
+            if (this.dom.chatSendBtn) this.dom.chatSendBtn.disabled = false;
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -662,6 +662,45 @@ body {
     margin-right: 8px;
 }
 
+/* Chat Modal Styles */
+.chat-messages {
+    max-height: 400px;
+    overflow-y: auto;
+    margin-bottom: 16px;
+}
+
+.chat-message {
+    margin-bottom: 8px;
+}
+
+.chat-message.user {
+    text-align: right;
+    color: var(--accent-primary);
+}
+
+.chat-message.bot {
+    text-align: left;
+    color: var(--text-primary);
+}
+
+.chat-input-container {
+    display: flex;
+    gap: 8px;
+}
+
+.chat-input-container input {
+    flex: 1;
+    padding: 12px 16px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-primary);
+}
+
+.chat-input-container button {
+    padding: 12px 20px;
+}
+
 @media (max-width: 768px) {
     .header-title h1 {
         font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- Add chat button to header and modal chat UI for testing prompts
- Style chat modal and messages for dark theme
- Implement chat logic using existing OpenRouter AI settings

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b757edc278832a8a27dbeedca49e19