### PR TITLE
Add internal chat interface for prompt testing

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>PromptForge Chat</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #000;
+            color: #e0e0e0;
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+        }
+        .chat-header {
+            background: #121212;
+            padding: 12px 16px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+        }
+        .chat-header h1 {
+            font-size: 1.2em;
+            color: #00b4d8;
+        }
+        .chat-body {
+            flex: 1;
+            overflow-y: auto;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+        }
+        .message {
+            margin-bottom: 12px;
+            display: flex;
+            flex-direction: column;
+            max-width: 80%;
+            font-size: 15px;
+        }
+        .message.user {
+            align-self: flex-end;
+        }
+        .message.bot {
+            align-self: flex-start;
+        }
+        .message-content {
+            padding: 12px 16px;
+            border-radius: 18px;
+            line-height: 1.4;
+            word-wrap: break-word;
+        }
+        .message.user .message-content {
+            background: #00598a;
+            color: #fff;
+            border-bottom-right-radius: 4px;
+        }
+        .message.bot .message-content {
+            background: #1e1e1e;
+            color: #e0e0e0;
+            border-bottom-left-radius: 4px;
+        }
+        .chat-footer {
+            padding: 10px;
+            background: #121212;
+            display: flex;
+            gap: 10px;
+        }
+        #user-input {
+            flex: 1;
+            padding: 12px 16px;
+            background: rgba(255,255,255,0.05);
+            border: 1px solid #333;
+            border-radius: 28px;
+            color: #e0e0e0;
+            outline: none;
+        }
+        #send-btn {
+            background: #00b4d8;
+            border: none;
+            color: #fff;
+            width: 48px;
+            height: 48px;
+            border-radius: 50%;
+            cursor: pointer;
+        }
+        /* Settings modal */
+        .modal {
+            display: none;
+            position: fixed;
+            top: 0; left: 0;
+            width: 100%; height: 100%;
+            background: rgba(0,0,0,0.7);
+            justify-content: center;
+            align-items: center;
+        }
+        .modal-content {
+            background: #121212;
+            padding: 20px;
+            border-radius: 8px;
+            width: 90%;
+            max-width: 400px;
+        }
+        .modal-content h2 {
+            margin-top: 0;
+            color: #00b4d8;
+        }
+        .modal-content label {
+            display: block;
+            margin: 15px 0 5px;
+        }
+        .modal-content input {
+            width: 100%;
+            padding: 8px;
+            background: rgba(255,255,255,0.05);
+            border: 1px solid #333;
+            border-radius: 6px;
+            color: #e0e0e0;
+        }
+        .modal-actions {
+            margin-top: 20px;
+            text-align: right;
+        }
+        .modal-actions button {
+            background: #00b4d8;
+            border: none;
+            color: #fff;
+            padding: 8px 16px;
+            border-radius: 6px;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <div class="chat-header">
+        <h1>ChatBot</h1>
+        <button id="settings-btn" class="header-btn" style="background:none;border:none;color:#e0e0e0;font-size:1.1em;cursor:pointer" title="Settings"><i class="fas fa-cog"></i></button>
+    </div>
+    <div id="chat-body" class="chat-body"></div>
+    <div class="chat-footer">
+        <input type="text" id="user-input" placeholder="Type a message..." autocomplete="off"/>
+        <button id="send-btn"><i class="fas fa-paper-plane"></i></button>
+    </div>
+
+    <div id="settings-modal" class="modal">
+        <div class="modal-content">
+            <h2>Settings</h2>
+            <label for="api-key">OpenRouter API Key</label>
+            <input type="password" id="api-key" placeholder="sk-..." />
+            <label for="model">Model</label>
+            <input type="text" id="model" placeholder="qwen/qwen3-235b-a22b:free" />
+            <div class="modal-actions">
+                <button id="save-settings">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const chatBody = document.getElementById('chat-body');
+        const userInput = document.getElementById('user-input');
+        const sendBtn = document.getElementById('send-btn');
+        const settingsBtn = document.getElementById('settings-btn');
+        const settingsModal = document.getElementById('settings-modal');
+        const apiKeyInput = document.getElementById('api-key');
+        const modelInput = document.getElementById('model');
+        const saveSettings = document.getElementById('save-settings');
+
+        let settings = {
+            apiKey: localStorage.getItem('chat_api_key') || '',
+            model: localStorage.getItem('chat_model') || 'qwen/qwen3-235b-a22b:free'
+        };
+        apiKeyInput.value = settings.apiKey;
+        modelInput.value = settings.model;
+
+        function displayMessage(sender, content) {
+            const messageDiv = document.createElement('div');
+            messageDiv.className = 'message ' + sender;
+            const bubble = document.createElement('div');
+            bubble.className = 'message-content';
+            bubble.textContent = content;
+            messageDiv.appendChild(bubble);
+            chatBody.appendChild(messageDiv);
+            chatBody.scrollTop = chatBody.scrollHeight;
+        }
+
+        async function sendMessage() {
+            const message = userInput.value.trim();
+            if (!message) return;
+            if (!settings.apiKey) {
+                alert('Please set your OpenRouter API key in settings.');
+                return;
+            }
+
+            displayMessage('user', message);
+            userInput.value = '';
+
+            try {
+                const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${settings.apiKey}`
+                    },
+                    body: JSON.stringify({
+                        model: settings.model,
+                        messages: [
+                            { role: 'system', content: 'You are a helpful assistant.' },
+                            { role: 'user', content: message }
+                        ]
+                    })
+                });
+                if (!response.ok) {
+                    const err = await response.json();
+                    throw new Error(err.error?.message || 'API request failed');
+                }
+                const data = await response.json();
+                const botMessage = data.choices[0].message.content;
+                displayMessage('bot', botMessage);
+            } catch (err) {
+                displayMessage('bot', 'Error: ' + err.message);
+            }
+        }
+
+        sendBtn.addEventListener('click', sendMessage);
+        userInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                sendMessage();
+            }
+        });
+
+        settingsBtn.addEventListener('click', () => {
+            settingsModal.style.display = 'flex';
+        });
+        saveSettings.addEventListener('click', () => {
+            settings.apiKey = apiKeyInput.value.trim();
+            settings.model = modelInput.value.trim() || 'qwen/qwen3-235b-a22b:free';
+            localStorage.setItem('chat_api_key', settings.apiKey);
+            localStorage.setItem('chat_model', settings.model);
+            settingsModal.style.display = 'none';
+        });
+        window.addEventListener('click', (e) => {
+            if (e.target === settingsModal) settingsModal.style.display = 'none';
+        });
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -91,6 +91,9 @@
                 <button class="header-btn" id="export-prompts-btn" title="Export Prompts">
                     <i class="fas fa-file-export"></i>
                 </button>
+                <button class="header-btn" id="chat-btn" title="Chat">
+                    <i class="fas fa-comments"></i>
+                </button>
                 <button class="header-btn" id="theme-toggle-btn" title="Toggle Theme">
                     <i class="fas fa-sun"></i>
                 </button>

--- a/script.js
+++ b/script.js
@@ -40,6 +40,7 @@ class PromptForgeApp {
                 importBtn: document.getElementById('import-prompts-btn'),
                 importInput: document.getElementById('import-prompts-input'),
                 exportBtn: document.getElementById('export-prompts-btn'),
+                chatBtn: document.getElementById('chat-btn'),
                 themeToggleBtn: document.getElementById('theme-toggle-btn'),
                 newEditModal: document.getElementById('new-edit-prompt-modal'),
                 newEditModalTitle: document.getElementById('new-edit-modal-title'),
@@ -239,6 +240,9 @@ class PromptForgeApp {
         this.dom.importBtn.addEventListener('click', () => this.dom.importInput.click());
         this.dom.importInput.addEventListener('change', (e) => this.importPrompts(e));
         this.dom.exportBtn.addEventListener('click', () => this.exportPrompts());
+        this.dom.chatBtn.addEventListener('click', () => {
+            window.location.href = 'chat.html';
+        });
         this.dom.themeToggleBtn.addEventListener('click', () => this.toggleTheme());
         this.dom.promptForm.addEventListener('submit', (e) => {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- add chat button in header to open in-app prompt testing interface
- implement basic ChatBot page with dark theme and OpenRouter support
- wire up script to navigate to chat interface

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b757edc278832a8a27dbeedca49e19